### PR TITLE
Introduce Tooltips public interface

### DIFF
--- a/Sources/SwiftTooltip/SwiftTooltip.swift
+++ b/Sources/SwiftTooltip/SwiftTooltip.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-public struct Tooltip: Identifiable {
+public struct TooltipItem: Identifiable {
     
     public var id: String = UUID().uuidString
     public var message: String
@@ -27,7 +27,20 @@ public struct Tooltip: Identifiable {
 
 public protocol TooltipHighlightedView {
     
-    var tooltip: Tooltip { get }
+    var tooltip: TooltipItem { get }
     
 }
 
+public final class Tooltips {
+    
+    public static func show(
+        _ tooltips: [TooltipItem],
+        in presenterVC: UIViewController?,
+        completion: (() -> Void)?
+    ) {
+        let coordinator = TooltipViewController.Coordinator(presenterVC: presenterVC)
+        coordinator.start(with: tooltips, onFinish: completion)
+    }
+    
+    
+}

--- a/Sources/SwiftTooltip/TooltipViewController+Coordinator.swift
+++ b/Sources/SwiftTooltip/TooltipViewController+Coordinator.swift
@@ -26,7 +26,7 @@ extension TooltipViewController {
         }
         
         func start(
-            with tooltips: [Tooltip],
+            with tooltips: [TooltipItem],
             onFinish: (() -> Void)?
         ) {
             self.onFinish = onFinish

--- a/Sources/SwiftTooltip/TooltipViewController+ViewModel.swift
+++ b/Sources/SwiftTooltip/TooltipViewController+ViewModel.swift
@@ -14,11 +14,11 @@ extension TooltipViewController {
         // MARK: - Properties
         
         var onShowNextTip: ((TooltipDesription) -> Void)?
-        private var tooltips: [Tooltip]
+        private var tooltips: [TooltipItem]
         private let coordinator: TooltipCoordinator
                 
         init(
-            tooltips: [Tooltip],
+            tooltips: [TooltipItem],
             coordinator: TooltipCoordinator
         ) {
             self.tooltips = tooltips
@@ -51,7 +51,7 @@ extension TooltipViewController {
     }
     
     struct TooltipDesription {
-        var tooltip: Tooltip
+        var tooltip: TooltipItem
     }
     
 }

--- a/Sources/SwiftTooltip/TooltipViewController.swift
+++ b/Sources/SwiftTooltip/TooltipViewController.swift
@@ -62,7 +62,7 @@ final class TooltipViewController: UIViewController {
         currentHighlightedView?.removeFromSuperview()
     }
     
-    private func tooltipView(for tooltip: Tooltip) -> UIView? {
+    private func tooltipView(for tooltip: TooltipItem) -> UIView? {
         for subview in tooltipViews {
             if let tooltipView = subview as? TooltipHighlightedView, tooltipView.tooltip.id == tooltip.id {
                 return subview

--- a/Tests/SwiftTooltipTests/SwiftTooltipTests.swift
+++ b/Tests/SwiftTooltipTests/SwiftTooltipTests.swift
@@ -5,7 +5,7 @@
         
         func testExample() {
             let message = "Tooltip message"
-            let tooltip = Tooltip(message: message, calloutConfig: .default)
+            let tooltip = TooltipItem(message: message, calloutConfig: .default)
             XCTAssertEqual(tooltip.message, message)
         }
     }


### PR DESCRIPTION
The main idea is to simplify usage as much as possible.

```
Tooltips.show([.firstTooltip, .secondTooltip], in: self)
```

Since `Tooltips` is pretty close to `Tooltip`, `Tooltip` has been renamed to TooltipItem. In turn, `TooltipItem` brings more sense to what it does (description of a tooltip item)